### PR TITLE
Fix veggiaApi.load method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veggie",
-  "version": "3.0.0-beta.11",
+  "version": "3.0.1-beta.11",
   "description": "Interactive mock server for profiling user scenarios",
   "main": "dist/veggie.js",
   "module": "dist/veggie.es.js",

--- a/src/client.js
+++ b/src/client.js
@@ -138,7 +138,7 @@ export async function hang (url) {
 
 export async function load (name) {
   const id = await _getProfileId(name)
-  const res = await _loadProfile({ id })
+  const res = await _loadProfile({payload: {id, name}})
 
   return res
 }

--- a/src/server.js
+++ b/src/server.js
@@ -163,7 +163,7 @@ apiRouter.post('/store/profile', (req, res) => {
  * @path /veggie/api/v1/store/profile
  */
 apiRouter.put('/store/profile', (req, res) => {
-  const { id } = req.body
+  const { id, name } = req.body
   const profile = profileByIdSel(id)
 
   if (id) {
@@ -177,7 +177,7 @@ apiRouter.put('/store/profile', (req, res) => {
 
     sendJSON(res, { status: 'success', message })
   } else {
-    const error = `could not find profile with id ${id}`
+    const error = `could not find profile: ${name}`
     serverError(error)
 
     sendJSON(res, { status: 'failed', error }, 400)

--- a/test/index.js
+++ b/test/index.js
@@ -347,11 +347,16 @@ describe('a server', () => {
         })
 
         it('can load a profile', () => {
-          return veggieApi._getProfileId('test')
-            .then(id => veggieApi._loadProfile({ payload: { id } }))
+          return veggieApi.load('test')
             .then(() => fetchJSON('/obj'))
             .then(d => assert(false)) // Fail
             .catch(e => assert(/409/.test(e)))
+        })
+
+        it('will return correct status for a profile not found', () => {
+          return veggieApi.load('non-existant-profile')
+          .then(d => assert(d.status === 'failed'))
+          .catch(e => assert(false))
         })
 
         it('can save an empty profile to disk', () => {


### PR DESCRIPTION
veggieApi.load was passing in id only to apiCall function resulting in empty req.body inside of apiRouter.put 

This update wraps veggieApi.load in payload object and includes name property for more descriptive response object that will read like: 'could not find profile: non-existant-profile'  instead of 'could not find profile id undefined'